### PR TITLE
機能追加: 出欠調整の管理者向け登録・編集・削除機能

### DIFF
--- a/PRPs/attendance-link-management.md
+++ b/PRPs/attendance-link-management.md
@@ -1,0 +1,351 @@
+## Goal
+
+Add comprehensive attendance link management functionality for administrators within the existing attendance tab. Implement create, edit, and delete operations for attendance forms while maintaining the existing read-only display for viewers. The feature should integrate seamlessly into the current AttendanceTab component using role-based access control patterns established in the codebase.
+
+## Issue Link
+
+https://github.com/atsu0127/orch-link/issues/14
+
+## Why
+
+- **Admin Efficiency**: Administrators currently have no way to manage attendance links through the UI
+- **User Experience**: Provides unified interface for attendance management within existing tab structure
+- **Role-Based Access**: Maintains security by showing management controls only to administrators
+- **Consistency**: Follows established CRUD patterns from concert management functionality
+
+## What
+
+### User-Visible Behavior
+
+**For Administrators:**
+- See existing attendance forms with edit/delete buttons
+- "新規出欠調整を作成" button to add new attendance links
+- Modal forms for creating/editing attendance forms (title, URL, description)
+- Delete confirmation dialogs with appropriate warnings
+- Success/error notifications for all operations
+- Real-time list updates after CRUD operations
+
+**For Viewers:**
+- Unchanged read-only display of attendance forms
+- No administrative controls visible
+
+### Technical Requirements
+
+- Role-based UI rendering using `useAuth` hook
+- Form validation for required fields (title, URL)
+- URL format validation for external form links
+- Proper error handling and user feedback
+- Mobile-responsive design consistency
+- TypeScript type safety throughout
+
+### Success Criteria
+
+- [ ] Admin can create new attendance forms via modal
+- [ ] Admin can edit existing attendance forms 
+- [ ] Admin can delete attendance forms with confirmation
+- [ ] Viewers see read-only display (unchanged behavior)
+- [ ] All operations show proper loading states and notifications
+- [ ] Form validation prevents invalid submissions
+- [ ] Mobile-responsive design maintained
+- [ ] No TypeScript errors or lint issues
+
+## All Needed Context
+
+### Documentation & References
+
+```yaml
+- file: src/components/features/concerts/ConcertManagement.tsx
+  why: CRUD operation patterns, state management, modal handling, delete confirmations
+  critical: Shows handleFormSubmit, loadConcerts, handleDelete patterns
+
+- file: src/components/features/concerts/ConcertForm.tsx  
+  why: Form implementation patterns, validation, error handling
+  critical: Form state management and handleInputChange pattern
+
+- file: src/components/features/attendance/AttendanceTab.tsx
+  why: Current implementation to extend, UI structure to preserve
+  critical: Read-only display must be maintained for viewers
+
+- file: src/app/api/concerts/route.ts
+  why: API endpoint patterns for PUT/DELETE operations
+  critical: Authentication checks, validation patterns, response formats
+
+- file: src/app/api/attendance/route.ts
+  why: Existing POST endpoint, authentication and validation patterns
+  critical: Already implements admin role checking and AttendanceForm creation
+
+- file: src/components/features/auth/AuthProvider.tsx
+  why: useAuth hook for role-based rendering
+  critical: user.role === "admin" pattern for showing admin UI
+
+- file: src/lib/api-client.ts
+  why: API client patterns, error handling
+  critical: handleApiError function and fetch patterns with credentials
+
+- file: src/types/index.ts
+  why: AttendanceForm interface definition
+  critical: Required fields are id, concertId, title, url, description?, updatedAt
+
+- url: https://mantine.dev/core/modal/
+  why: Modal component usage for create/edit forms
+  
+- url: https://mantine.dev/core/notifications/
+  why: Success/error notification patterns
+</yaml>
+
+### Current Codebase Structure (Relevant Parts)
+
+```bash
+src/
+├── app/api/attendance/route.ts          # POST already exists, need PUT/DELETE
+├── components/features/attendance/
+│   └── AttendanceTab.tsx               # Component to extend with admin UI
+├── components/features/concerts/
+│   ├── ConcertManagement.tsx          # CRUD pattern reference
+│   └── ConcertForm.tsx                # Form pattern reference  
+├── lib/
+│   └── api-client.ts                  # Need attendance API client functions
+└── types/
+    ├── index.ts                       # AttendanceForm interface exists
+    └── concert.ts                     # ConcertFormData pattern reference
+```
+
+### Desired Codebase Changes
+
+```bash
+src/
+├── app/api/attendance/route.ts          # Add PUT and DELETE endpoints
+├── components/features/attendance/
+│   ├── AttendanceTab.tsx               # Extend with admin UI and CRUD logic
+│   └── AttendanceForm.tsx              # NEW: Form component for create/edit
+├── lib/
+│   └── api-client.ts                  # Add fetchAttendanceForms function
+└── types/
+    └── index.ts                       # Add AttendanceFormData interface
+```
+
+### Known Gotchas & Library Quirks
+
+```typescript
+// CRITICAL: Mantine notifications require notifications import
+import { notifications } from "@mantine/notifications";
+
+// CRITICAL: useAuth hook provides user.role for access control
+const { user } = useAuth();
+const isAdmin = user?.role === "admin";
+
+// CRITICAL: API routes must verify admin role for write operations
+const payload = await verifyToken(token);
+if (!payload || payload.role !== "admin") {
+  return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+}
+
+// CRITICAL: Attendance API expects concertId, title, url as required fields
+// description is optional
+
+// CRITICAL: Modal state management pattern
+const [isFormOpen, setIsFormOpen] = useState(false);
+const [editingItem, setEditingItem] = useState<AttendanceForm | null>(null);
+
+// CRITICAL: Delete confirmation uses modals.openConfirmModal
+modals.openConfirmModal({
+  title: "削除確認",
+  children: <Text>削除してもよろしいですか？</Text>,
+  labels: { confirm: "削除する", cancel: "キャンセル" },
+  confirmProps: { color: "red" },
+  onConfirm: () => performDelete(id),
+});
+```
+
+## Implementation Blueprint
+
+### Data Models and Structure
+
+The AttendanceForm model already exists in Prisma schema with required fields. Need to add TypeScript form data interface:
+
+```typescript
+// Add to src/types/index.ts
+export interface AttendanceFormData {
+  title: string;        // フォームタイトル  
+  url: string;          // 外部フォームURL
+  description?: string; // 補足説明（任意）
+}
+```
+
+### List of Tasks to Complete (In Order)
+
+```yaml
+Task 1: Extend API endpoints
+MODIFY src/app/api/attendance/route.ts:
+  - ADD PUT endpoint following concerts/route.ts pattern
+  - ADD DELETE endpoint following concerts/route.ts pattern  
+  - PRESERVE existing POST and GET endpoints
+  - KEEP identical authentication and validation patterns
+
+Task 2: Add form data types
+MODIFY src/types/index.ts:
+  - ADD AttendanceFormData interface 
+  - MIRROR pattern from ConcertFormData structure
+  - INCLUDE title, url, description fields
+
+Task 3: Create attendance form component
+CREATE src/components/features/attendance/AttendanceForm.tsx:
+  - MIRROR pattern from concerts/ConcertForm.tsx
+  - MODIFY field definitions for attendance form fields
+  - KEEP identical validation and submission patterns
+  - PRESERVE mobile-responsive design
+
+Task 4: Add API client functions  
+MODIFY src/lib/api-client.ts:
+  - ADD fetchAttendanceForms function following fetchConcerts pattern
+  - INCLUDE proper error handling with handleApiError
+  - KEEP credentials: "include" for JWT authentication
+
+Task 5: Extend AttendanceTab with admin functionality
+MODIFY src/components/features/attendance/AttendanceTab.tsx:
+  - ADD role-based UI rendering using useAuth hook
+  - ADD CRUD state management following ConcertManagement pattern
+  - ADD admin controls (create/edit/delete buttons)
+  - ADD modal management for forms
+  - PRESERVE existing read-only display for viewers
+  - INJECT admin UI elements while maintaining existing layout
+```
+
+### Per Task Pseudocode
+
+```typescript
+// Task 1: API Endpoints Pseudocode
+// PUT /api/attendance
+async function PUT(request: NextRequest) {
+  // PATTERN: Copy auth checks from concerts/route.ts PUT exactly
+  // VALIDATE: attendanceFormId, title, url (required), description (optional)
+  // UPDATE: prisma.attendanceForm.update with provided fields
+  // RETURN: Standard success response
+}
+
+// DELETE /api/attendance  
+async function DELETE(request: NextRequest) {
+  // PATTERN: Copy auth checks from concerts/route.ts DELETE exactly
+  // VALIDATE: attendanceFormId from query params
+  // DELETE: prisma.attendanceForm.delete with cascade protection
+  // RETURN: Standard success response
+}
+
+// Task 5: AttendanceTab Extension Pseudocode
+function AttendanceTab({ concertId, attendanceForms }) {
+  // PATTERN: Copy state management from ConcertManagement exactly
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const [localForms, setLocalForms] = useState(attendanceForms);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingForm, setEditingForm] = useState(null);
+
+  // CRITICAL: Preserve existing read-only display
+  // ADD: Admin-only header with "新規作成" button
+  // ADD: Edit/delete buttons to each form card (admin only)
+  // ADD: Modal with AttendanceForm component
+  // KEEP: All existing viewer functionality unchanged
+}
+```
+
+### Integration Points
+
+```yaml
+COMPONENTS:
+  - extend: src/components/features/attendance/AttendanceTab.tsx
+  - create: src/components/features/attendance/AttendanceForm.tsx
+  - pattern: "Mirror ConcertManagement modal and form patterns exactly"
+
+API_ROUTES:  
+  - extend: src/app/api/attendance/route.ts
+  - add: "PUT and DELETE endpoints with admin auth"
+  - pattern: "Copy concerts/route.ts authentication and validation exactly"
+
+TYPES:
+  - extend: src/types/index.ts  
+  - add: "AttendanceFormData interface"
+  - pattern: "Mirror ConcertFormData structure"
+
+CLIENT_API:
+  - extend: src/lib/api-client.ts
+  - add: "fetchAttendanceForms function"
+  - pattern: "Copy fetchConcerts pattern exactly"
+```
+
+## Validation Loop
+
+### Level 1: Syntax & Style
+
+```bash
+# Run these FIRST - fix any errors before proceeding
+npm run lint                    # ESLint validation
+npx tsc --noEmit               # TypeScript compilation check
+
+# Expected: No errors. If errors exist, read them carefully and fix.
+```
+
+### Level 2: Manual Testing
+
+```bash
+# Start development server
+npm run dev
+
+# Test scenarios to verify:
+# 1. Login as admin - should see create/edit/delete controls
+# 2. Login as viewer - should see read-only display only  
+# 3. Create new attendance form - should appear in list
+# 4. Edit existing form - should update in list
+# 5. Delete form - should remove from list with confirmation
+# 6. Form validation - should prevent empty title/invalid URL
+# 7. Mobile responsive - should work on mobile screen sizes
+```
+
+### Level 3: API Testing (Optional)
+
+```bash
+# Test API endpoints directly
+# Create attendance form (should work for admin)
+curl -X POST http://localhost:3000/api/attendance \
+  -H "Content-Type: application/json" \
+  -H "Cookie: auth-token=<admin-token>" \
+  -d '{"concertId": "test-concert", "title": "Test Form", "url": "https://forms.google.com/test"}'
+
+# Expected: {"success": true, "message": "出欠調整を作成しました"}
+```
+
+## Final Validation Checklist
+
+- [ ] No TypeScript errors: `npx tsc --noEmit`
+- [ ] No lint errors: `npm run lint` 
+- [ ] Admin can create attendance forms via modal
+- [ ] Admin can edit existing forms by clicking edit button
+- [ ] Admin can delete forms with confirmation dialog
+- [ ] Viewers see unchanged read-only display
+- [ ] Form validation prevents empty title/URL
+- [ ] All operations show loading states and notifications
+- [ ] Mobile-responsive design maintained
+- [ ] JWT authentication working for all operations
+- [ ] Database operations complete successfully
+
+## Anti-Patterns to Avoid
+
+- ❌ Don't break existing read-only functionality for viewers
+- ❌ Don't create separate admin pages - integrate into existing tab
+- ❌ Don't skip role-based access control checks
+- ❌ Don't ignore existing UI/UX patterns from concert management
+- ❌ Don't hardcode text that should be in Japanese
+- ❌ Don't skip form validation on both client and server
+- ❌ Don't forget to handle loading and error states properly
+
+---
+
+## Confidence Score: 9/10
+
+High confidence due to:
+- ✅ Existing similar CRUD patterns in ConcertManagement
+- ✅ Well-established API endpoint patterns
+- ✅ Clear authentication and authorization patterns
+- ✅ Comprehensive component examples to follow
+- ✅ Detailed validation and error handling examples
+
+Minor risk: Integration complexity of adding admin UI to existing read-only component, but pattern is clear from other parts of codebase.

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getTokenFromCookie, verifyToken } from "@/lib/auth";
+import { verifyToken } from "@/lib/auth";
 import { getAttendanceFormsByConcert } from "@/lib/queries";
 import { prisma } from "@/lib/db";
 
@@ -110,6 +110,132 @@ export async function POST(request: NextRequest) {
 
   } catch (error) {
     console.error("Attendance creation error:", error);
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PUT /api/attendance
+ * 出欠調整更新API（管理者のみ）
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    // JWT認証チェック
+    const token = request.cookies.get("auth-token")?.value;
+    if (!token) {
+      return NextResponse.json(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+    }
+
+    const payload = await verifyToken(token);
+    if (!payload || payload.role !== "admin") {
+      return NextResponse.json(
+        { error: "管理者権限が必要です" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { 
+      attendanceFormId, 
+      title, 
+      url,
+      description
+    } = body;
+
+    // 入力値検証
+    if (!attendanceFormId) {
+      return NextResponse.json(
+        { error: "出欠調整IDが必要です" },
+        { status: 400 }
+      );
+    }
+
+    // データベースの出欠調整を更新
+    const updateData: Record<string, string> = {};
+    if (title !== undefined) updateData.title = title;
+    if (url !== undefined) updateData.url = url;
+    if (description !== undefined) updateData.description = description;
+    
+    await prisma.attendanceForm.update({
+      where: { id: attendanceFormId },
+      data: updateData,
+    });
+    
+    console.log("出欠調整更新完了:", {
+      attendanceFormId,
+      updatedBy: payload.userId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "出欠調整を更新しました",
+    });
+
+  } catch (error) {
+    console.error("Attendance update error:", error);
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/attendance
+ * 出欠調整削除API（管理者のみ）
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    // JWT認証チェック
+    const token = request.cookies.get("auth-token")?.value;
+    if (!token) {
+      return NextResponse.json(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+    }
+
+    const payload = await verifyToken(token);
+    if (!payload || payload.role !== "admin") {
+      return NextResponse.json(
+        { error: "管理者権限が必要です" },
+        { status: 403 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const attendanceFormId = searchParams.get('id');
+
+    if (!attendanceFormId) {
+      return NextResponse.json(
+        { error: "出欠調整IDが必要です" },
+        { status: 400 }
+      );
+    }
+
+    // データベースから出欠調整を削除
+    await prisma.attendanceForm.delete({
+      where: { id: attendanceFormId },
+    });
+    
+    console.log("出欠調整削除完了:", {
+      attendanceFormId,
+      deletedBy: payload.userId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "出欠調整を削除しました",
+    });
+
+  } catch (error) {
+    console.error("Attendance deletion error:", error);
     return NextResponse.json(
       { error: "サーバーエラーが発生しました" },
       { status: 500 }

--- a/src/components/features/attendance/AttendanceForm.tsx
+++ b/src/components/features/attendance/AttendanceForm.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Paper,
+  Title,
+  TextInput,
+  Textarea,
+  Button,
+  Stack,
+  Alert,
+} from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
+import { AttendanceFormData } from "@/types";
+import type { AttendanceForm } from "@/types";
+
+interface AttendanceFormProps {
+  /** 編集モード時の初期データ */
+  initialData?: AttendanceForm;
+  /** フォーム送信時のハンドラ */
+  onSubmit: (data: AttendanceFormData) => Promise<void>;
+  /** フォーム送信中の状態 */
+  isLoading?: boolean;
+  /** フォームタイトル */
+  title?: string;
+  /** キャンセルボタンのハンドラ */
+  onCancel?: () => void;
+}
+
+/**
+ * 出欠調整作成・編集フォームコンポーネント
+ * 管理者専用の出欠調整データ入力フォーム
+ */
+export function AttendanceForm({
+  initialData,
+  onSubmit,
+  isLoading = false,
+  title = "出欠調整を作成",
+  onCancel,
+}: AttendanceFormProps) {
+  // フォーム状態管理
+  const [formData, setFormData] = useState<AttendanceFormData>({
+    title: initialData?.title || "",
+    url: initialData?.url || "",
+    description: initialData?.description || "",
+  });
+  const [error, setError] = useState("");
+
+  /**
+   * フォーム送信処理
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    // 入力値検証
+    if (!formData.title.trim()) {
+      setError("フォームタイトルを入力してください");
+      return;
+    }
+
+    if (!formData.url.trim()) {
+      setError("フォームURLを入力してください");
+      return;
+    }
+
+    // URL形式の検証
+    try {
+      new URL(formData.url);
+    } catch {
+      setError("有効なURLを入力してください");
+      return;
+    }
+
+    try {
+      await onSubmit(formData);
+    } catch (error) {
+      console.error("Attendance form submission error:", error);
+      setError("送信に失敗しました。もう一度お試しください。");
+    }
+  };
+
+  /**
+   * 入力値変更ハンドラ
+   */
+  const handleInputChange = (field: keyof AttendanceFormData, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+    // エラーをクリア
+    if (error) setError("");
+  };
+
+  return (
+    <Paper shadow="sm" p="lg" radius="md" className="w-full max-w-md">
+      <Title order={3} className="text-center mb-6">
+        {title}
+      </Title>
+
+      <form onSubmit={handleSubmit}>
+        <Stack gap="md">
+          {/* フォームタイトル */}
+          <TextInput
+            label="フォームタイトル"
+            placeholder="第○回定期演奏会 出欠調整"
+            value={formData.title}
+            onChange={(e) => handleInputChange('title', e.currentTarget.value)}
+            required
+            disabled={isLoading}
+          />
+
+          {/* フォームURL */}
+          <TextInput
+            label="フォームURL"
+            placeholder="https://forms.google.com/..."
+            value={formData.url}
+            onChange={(e) => handleInputChange('url', e.currentTarget.value)}
+            required
+            disabled={isLoading}
+          />
+
+          {/* 説明文 */}
+          <Textarea
+            label="説明文（任意）"
+            placeholder="出欠調整に関する補足説明があれば入力してください"
+            value={formData.description}
+            onChange={(e) => handleInputChange('description', e.currentTarget.value)}
+            disabled={isLoading}
+            minRows={3}
+          />
+
+          {/* エラーメッセージ */}
+          {error && (
+            <Alert icon={<IconAlertCircle size="1rem" />} color="red">
+              {error}
+            </Alert>
+          )}
+
+          {/* 送信ボタン */}
+          <Stack gap="sm" className="mt-4">
+            <Button
+              type="submit"
+              loading={isLoading}
+              size="md"
+              className="w-full"
+            >
+              {initialData ? "更新する" : "作成する"}
+            </Button>
+
+            {/* キャンセルボタン */}
+            {onCancel && (
+              <Button
+                variant="light"
+                onClick={onCancel}
+                disabled={isLoading}
+                size="md"
+                className="w-full"
+              >
+                キャンセル
+              </Button>
+            )}
+          </Stack>
+        </Stack>
+      </form>
+    </Paper>
+  );
+}

--- a/src/components/features/attendance/AttendanceTab.tsx
+++ b/src/components/features/attendance/AttendanceTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import {
   Paper,
   Title,
@@ -10,14 +10,26 @@ import {
   Alert,
   Group,
   Badge,
+  Modal,
+  ActionIcon,
 } from "@mantine/core";
+import { modals } from "@mantine/modals";
+import { notifications } from "@mantine/notifications";
 import {
   IconExternalLink,
   IconInfoCircle,
   IconClipboardList,
+  IconPlus,
+  IconEdit,
+  IconTrash,
+  IconCheck,
+  IconAlertCircle,
 } from "@tabler/icons-react";
 import { formatDate } from "@/lib/utils";
-import { AttendanceForm } from "@/types";
+import { AttendanceForm, AttendanceFormData } from "@/types";
+import { AttendanceForm as AttendanceFormComponent } from "./AttendanceForm";
+import { useAuth } from "@/components/features/auth/AuthProvider";
+import { fetchAttendanceForms, handleApiError } from "@/lib/api-client";
 
 interface AttendanceTabProps {
   concertId: string;
@@ -25,12 +37,221 @@ interface AttendanceTabProps {
 }
 
 /**
+ * 出欠調整管理APIレスポンス型
+ */
+interface AttendanceApiResponse {
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+/**
  * 出欠調整タブコンポーネント
  * 外部フォーム（Google Forms等）へのリンクを表示
  */
-export function AttendanceTab({ attendanceForms }: AttendanceTabProps) {
+export function AttendanceTab({ concertId, attendanceForms }: AttendanceTabProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+
+  // 状態管理
+  const [localForms, setLocalForms] = useState<AttendanceForm[]>(attendanceForms);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingForm, setEditingForm] = useState<AttendanceForm | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * 出欠調整一覧を再読み込み
+   */
+  const loadAttendanceForms = async () => {
+    try {
+      setError(null);
+      const forms = await fetchAttendanceForms(concertId);
+      setLocalForms(forms);
+    } catch (error) {
+      console.error("Attendance forms loading error:", error);
+      setError(`出欠調整一覧の読み込みに失敗しました: ${handleApiError(error)}`);
+    }
+  };
+
+  /**
+   * 出欠調整作成API呼び出し
+   */
+  const createAttendanceForm = async (data: AttendanceFormData): Promise<void> => {
+    const response = await fetch("/api/attendance", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ concertId, ...data }),
+    });
+
+    const result: AttendanceApiResponse = await response.json();
+
+    if (!response.ok || !result.success) {
+      throw new Error(result.error || `出欠調整の作成に失敗しました: ${response.status}`);
+    }
+  };
+
+  /**
+   * 出欠調整更新API呼び出し
+   */
+  const updateAttendanceForm = async (formId: string, data: AttendanceFormData): Promise<void> => {
+    const response = await fetch("/api/attendance", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ attendanceFormId: formId, ...data }),
+    });
+
+    const result: AttendanceApiResponse = await response.json();
+
+    if (!response.ok || !result.success) {
+      throw new Error(result.error || `出欠調整の更新に失敗しました: ${response.status}`);
+    }
+  };
+
+  /**
+   * 出欠調整削除API呼び出し
+   */
+  const deleteAttendanceForm = async (formId: string): Promise<void> => {
+    const response = await fetch(`/api/attendance?id=${formId}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+
+    const result: AttendanceApiResponse = await response.json();
+
+    if (!response.ok || !result.success) {
+      throw new Error(result.error || `出欠調整の削除に失敗しました: ${response.status}`);
+    }
+  };
+
+  /**
+   * フォーム送信処理
+   */
+  const handleFormSubmit = async (data: AttendanceFormData) => {
+    try {
+      setIsLoading(true);
+
+      if (editingForm) {
+        // 更新
+        await updateAttendanceForm(editingForm.id, data);
+        notifications.show({
+          title: "更新完了",
+          message: "出欠調整を更新しました",
+          color: "green",
+          icon: <IconCheck size="1rem" />,
+        });
+      } else {
+        // 新規作成
+        await createAttendanceForm(data);
+        notifications.show({
+          title: "作成完了",
+          message: "出欠調整を作成しました",
+          color: "green",
+          icon: <IconCheck size="1rem" />,
+        });
+      }
+
+      // フォームを閉じて一覧を再読み込み
+      handleCloseForm();
+      await loadAttendanceForms();
+
+    } catch (error) {
+      console.error("Form submission error:", error);
+      notifications.show({
+        title: "エラー",
+        message: handleApiError(error),
+        color: "red",
+        icon: <IconAlertCircle size="1rem" />,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /**
+   * 新規作成モーダルを開く
+   */
+  const handleCreateNew = () => {
+    setEditingForm(null);
+    setIsFormOpen(true);
+  };
+
+  /**
+   * 編集モーダルを開く
+   */
+  const handleEdit = (form: AttendanceForm) => {
+    setEditingForm(form);
+    setIsFormOpen(true);
+  };
+
+  /**
+   * 削除確認ダイアログ
+   */
+  const handleDelete = (form: AttendanceForm) => {
+    modals.openConfirmModal({
+      title: "出欠調整を削除",
+      children: (
+        <Stack gap="sm">
+          <Text size="sm">
+            「{form.title}」を削除してもよろしいですか？
+          </Text>
+          <Alert color="yellow" variant="light">
+            <Text size="sm">
+              <strong>注意:</strong> この操作は取り消すことができません。
+            </Text>
+          </Alert>
+        </Stack>
+      ),
+      labels: { confirm: "削除する", cancel: "キャンセル" },
+      confirmProps: { color: "red" },
+      onConfirm: () => performDelete(form.id),
+    });
+  };
+
+  /**
+   * 削除実行処理
+   */
+  const performDelete = async (formId: string) => {
+    try {
+      setIsLoading(true);
+      await deleteAttendanceForm(formId);
+      
+      notifications.show({
+        title: "削除完了",
+        message: "出欠調整を削除しました",
+        color: "green",
+        icon: <IconCheck size="1rem" />,
+      });
+      
+      // 一覧を再読み込み
+      await loadAttendanceForms();
+      
+    } catch (error) {
+      console.error("Delete error:", error);
+      notifications.show({
+        title: "エラー",
+        message: handleApiError(error),
+        color: "red",
+        icon: <IconAlertCircle size="1rem" />,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /**
+   * フォームを閉じる
+   */
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+    setEditingForm(null);
+  };
+
   // 演奏会に紐づく出欠調整がない場合
-  if (attendanceForms.length === 0) {
+  // 演奏会に紐づく出欠調整がない場合
+  if (localForms.length === 0) {
     return (
       <div className="text-center py-12">
         <IconClipboardList size={48} className="mx-auto text-gray-400 mb-4" />
@@ -38,8 +259,18 @@ export function AttendanceTab({ attendanceForms }: AttendanceTabProps) {
           出欠調整はまだ準備されていません
         </Text>
         <Text size="sm" className="text-gray-500">
-          管理者がフォームを準備次第、こちらに表示されます
+          {isAdmin ? "新規作成ボタンから出欠調整を作成してください" : "管理者がフォームを準備次第、こちらに表示されます"}
         </Text>
+        {isAdmin && (
+          <Button
+            leftSection={<IconPlus size="1rem" />}
+            onClick={handleCreateNew}
+            className="mt-4"
+            disabled={isLoading}
+          >
+            新規出欠調整を作成
+          </Button>
+        )}
       </div>
     );
   }
@@ -48,16 +279,37 @@ export function AttendanceTab({ attendanceForms }: AttendanceTabProps) {
     <Stack gap="lg">
       {/* ヘッダー情報 */}
       <div>
-        <Title order={3} className="mb-2">
-          出欠調整
-        </Title>
-        <Text size="sm" className="text-gray-600">
-          演奏会への参加可否をお知らせください
-        </Text>
+        <Group justify="space-between" align="flex-start">
+          <div>
+            <Title order={3} className="mb-2">
+              出欠調整
+            </Title>
+            <Text size="sm" className="text-gray-600">
+              {isAdmin ? "出欠調整の管理" : "演奏会への参加可否をお知らせください"}
+            </Text>
+          </div>
+          {isAdmin && localForms.length > 0 && (
+            <Button
+              leftSection={<IconPlus size="1rem" />}
+              onClick={handleCreateNew}
+              disabled={isLoading}
+              size="sm"
+            >
+              新規作成
+            </Button>
+          )}
+        </Group>
       </div>
 
+      {/* エラー表示 */}
+      {error && (
+        <Alert icon={<IconAlertCircle size="1rem" />} color="red">
+          {error}
+        </Alert>
+      )}
+
       {/* 出欠調整一覧 */}
-      {attendanceForms.map((form) => (
+      {localForms.map((form) => (
         <Paper key={form.id} shadow="sm" p="lg" radius="md" className="border">
           <Stack gap="md">
             {/* フォームタイトルとバッジ */}
@@ -70,6 +322,28 @@ export function AttendanceTab({ attendanceForms }: AttendanceTabProps) {
                   外部フォーム
                 </Badge>
               </div>
+              {isAdmin && (
+                <Group gap="xs">
+                  <ActionIcon
+                    variant="light"
+                    color="blue"
+                    onClick={() => handleEdit(form)}
+                    disabled={isLoading}
+                    size="sm"
+                  >
+                    <IconEdit size="0.9rem" />
+                  </ActionIcon>
+                  <ActionIcon
+                    variant="light"
+                    color="red"
+                    onClick={() => handleDelete(form)}
+                    disabled={isLoading}
+                    size="sm"
+                  >
+                    <IconTrash size="0.9rem" />
+                  </ActionIcon>
+                </Group>
+              )}
             </Group>
 
             {/* 説明文 */}
@@ -115,6 +389,23 @@ export function AttendanceTab({ attendanceForms }: AttendanceTabProps) {
           <br />• 参加予定の変更がある場合は、お早めにご連絡ください
         </Text>
       </Alert>
+
+      {/* 作成・編集モーダル */}
+      <Modal
+        opened={isFormOpen}
+        onClose={handleCloseForm}
+        title={editingForm ? "出欠調整を編集" : "出欠調整を作成"}
+        centered
+        size="md"
+      >
+        <AttendanceFormComponent
+          initialData={editingForm || undefined}
+          onSubmit={handleFormSubmit}
+          isLoading={isLoading}
+          title={editingForm ? "出欠調整を編集" : "出欠調整を作成"}
+          onCancel={handleCloseForm}
+        />
+      </Modal>
     </Stack>
   );
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -4,18 +4,18 @@
  */
 
 import {
-  ConcertAPI,
-  ContactInfoAPI,
   ConcertsListResponse,
   ConcertDetailResponse,
+  AttendanceFormsListResponse,
   ContactInfoResponse,
 } from "@/types/serialized";
 import {
   deserializeConcertData,
   deserializeConcertDetailData,
+  deserializeAttendanceFormsData,
   deserializeContactInfoData,
 } from "@/lib/utils";
-import { Concert, ConcertDetail, ContactInfo } from "@/types";
+import { Concert, ConcertDetail, ContactInfo, AttendanceForm } from "@/types";
 
 /**
  * APIエラークラス
@@ -84,6 +84,35 @@ export async function fetchConcertData(
 
   // 日付フィールドをDateオブジェクトに変換
   return deserializeConcertDetailData(data.data);
+}
+
+/**
+ * 出欠調整一覧を取得
+ * @param concertId - 演奏会ID
+ * @returns 出欠調整リスト
+ */
+export async function fetchAttendanceForms(
+  concertId: string
+): Promise<AttendanceForm[]> {
+  const response = await fetch(`/api/attendance?concertId=${concertId}`, {
+    method: "GET",
+    credentials: "include", // JWT認証用クッキー
+  });
+
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      `出欠調整一覧の取得に失敗しました: ${response.status}`
+    );
+  }
+
+  const data: AttendanceFormsListResponse = await response.json();
+
+  if (!data.success) {
+    throw new ApiError(500, data.error || "出欠調整一覧の取得に失敗しました");
+  }
+
+  return deserializeAttendanceFormsData(data.data);
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,11 +8,12 @@
  * @param date - フォーマット対象の日付
  * @returns フォーマットされた日付文字列
  */
-import { Concert, ConcertDetail, ContactInfo } from "@/types";
+import { Concert, ConcertDetail, ContactInfo, AttendanceForm } from "@/types";
 import {
   ConcertAPI,
   ConcertDetailAPI,
   ContactInfoAPI,
+  AttendanceFormAPI,
 } from "@/types/serialized";
 
 export function formatDate(date: Date): string {
@@ -103,6 +104,18 @@ export function deserializeConcertData(data: ConcertAPI[]): Concert[] {
     ...concert,
     date: new Date(concert.date),
     updatedAt: new Date(concert.updatedAt),
+  }));
+}
+
+/**
+ * APIから取得したシリアライズされた出欠調整リストをデシリアライズ
+ * @param data - シリアライズされた出欠調整リスト
+ * @returns デシリアライズされた出欠調整リスト
+ */
+export function deserializeAttendanceFormsData(data: AttendanceFormAPI[]): AttendanceForm[] {
+  return data.map((form) => ({
+    ...form,
+    updatedAt: new Date(form.updatedAt),
   }));
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,13 @@ export interface AttendanceForm {
   updatedAt: Date; // 最終更新日時
 }
 
+// 出欠調整フォームデータ型定義
+export interface AttendanceFormData {
+  title: string; // フォームタイトル
+  url: string; // 外部フォームURL
+  description?: string; // 補足説明（任意）
+}
+
 // 楽譜型定義
 export interface Score {
   id: string;

--- a/src/types/serialized.ts
+++ b/src/types/serialized.ts
@@ -61,4 +61,5 @@ export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;
 // API呼び出しの具体的なレスポンス型
 export type ConcertsListResponse = ApiResponse<ConcertAPI[]>;
 export type ConcertDetailResponse = ApiResponse<ConcertDetailAPI>;
+export type AttendanceFormsListResponse = ApiResponse<AttendanceFormAPI[]>;
 export type ContactInfoResponse = ApiResponse<ContactInfoAPI>;


### PR DESCRIPTION
## 概要
出欠調整タブに管理者向けのCRUD機能を追加しました。管理者は出欠調整の作成・編集・削除が可能になり、閲覧者には従来通りの読み取り専用表示が継続されます。

## 詳細
**commit e5e8c3d**: PUT/DELETE APIエンドポイントと型定義を追加
- PUT /api/attendance: 出欠調整更新API（管理者のみ）
- DELETE /api/attendance: 出欠調整削除API（管理者のみ）
- AttendanceFormData型とAttendanceFormsListResponse型を追加

**commit 64ae4a2**: APIクライアント関数を追加
- fetchAttendanceForms関数を追加
- エラーハンドリングとデシリアライゼーション対応

**commit d477137**: 出欠調整フォームコンポーネントを作成
- 作成・編集用のフォームコンポーネント
- フィールド検証（タイトル・URL必須、URL形式チェック）
- モバイル対応レスポンシブデザイン

**commit c5055e7**: AttendanceTabに管理者向けCRUD機能を追加
- ロールベースUI（管理者のみ作成・編集・削除ボタン表示）
- モーダルフォーム統合と状態管理
- 削除確認ダイアログと通知システム
- 閲覧者の既存機能は完全に保持

## 注意
- 管理者権限（JWT role: "admin"）でのみCRUD操作が可能
- 閲覧者には管理ボタンが表示されず、従来通りの表示を維持
- 全ての操作でバリデーションとエラーハンドリングを実装

## Issue
close https://github.com/atsu0127/orch-link/issues/14