### PR TITLE
feat: 連絡機能強化 - メールボタン削除・コピー機能・管理者編集UI追加 (#21)

### DIFF
--- a/src/components/features/contact/ContactTab.tsx
+++ b/src/components/features/contact/ContactTab.tsx
@@ -10,11 +10,17 @@ import {
   Alert,
   Group,
   LoadingOverlay,
+  Modal,
+  TextInput,
+  Textarea,
 } from "@mantine/core";
-import { IconMail, IconInfoCircle } from "@tabler/icons-react";
+import { useClipboard } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import { IconMail, IconInfoCircle, IconCopy, IconCheck, IconEdit, IconX } from "@tabler/icons-react";
 import { formatDate } from "@/lib/utils";
 import { fetchContactInfo, handleApiError } from "@/lib/api-client";
 import { ContactInfo } from "@/types";
+import { useAuth } from "@/components/features/auth/AuthProvider";
 
 interface ContactTabProps {
   concertId: string;
@@ -25,9 +31,20 @@ interface ContactTabProps {
  * 管理者への連絡手段（メール）を提供
  */
 export function ContactTab({}: ContactTabProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+
   const [contactInfo, setContactInfo] = useState<ContactInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // 管理者編集モーダル用状態管理
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isFormLoading, setIsFormLoading] = useState(false);
+  const [formData, setFormData] = useState({ email: "", description: "" });
+
+  // useClipboardフックでコピー機能を追加
+  const clipboard = useClipboard({ timeout: 1000 });
 
   // コンポーネントマウント時に連絡先情報を取得
   useEffect(() => {
@@ -83,42 +100,124 @@ export function ContactTab({}: ContactTabProps) {
     );
   }
 
-  /**
-   * メール送信処理
-   * mailtoリンクでメーラーを起動
-   */
-  const handleSendEmail = () => {
-    const subject = encodeURIComponent(
-      "Orch Link エキストラからのお問い合わせ"
-    );
-    const body = encodeURIComponent(`
-演奏会についてお問い合わせがあります。
+  // 管理者編集モーダルを開く処理
+  const handleEditModalOpen = () => {
+    if (contactInfo) {
+      setFormData({
+        email: contactInfo.email,
+        description: contactInfo.description,
+      });
+      setIsEditModalOpen(true);
+    }
+  };
 
-【お問い合わせ内容】
-（こちらに内容をご記入ください）
+  // 管理者編集モーダルを閉じる処理
+  const handleEditModalClose = () => {
+    setIsEditModalOpen(false);
+    setFormData({ email: "", description: "" });
+  };
 
-【連絡先】
-お名前:
-メールアドレス:
-電話番号（任意）:
+  // フォーム送信処理
+  const handleFormSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
 
-よろしくお願いいたします。
-    `);
+    // バリデーション
+    if (!formData.email || !formData.description) {
+      notifications.show({
+        title: "エラー",
+        message: "メールアドレスと説明文は必須です",
+        color: "red",
+        icon: <IconX size="1rem" />,
+      });
+      return;
+    }
 
-    const mailtoUrl = `mailto:${contactInfo.email}?subject=${subject}&body=${body}`;
-    window.location.href = mailtoUrl;
+    // メールアドレス形式の検証（APIと同じregex）
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(formData.email)) {
+      notifications.show({
+        title: "エラー",
+        message: "有効なメールアドレスを入力してください",
+        color: "red",
+        icon: <IconX size="1rem" />,
+      });
+      return;
+    }
+
+    try {
+      setIsFormLoading(true);
+
+      const response = await fetch("/api/contact", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include", // JWT認証用クッキー
+        body: JSON.stringify({
+          email: formData.email,
+          description: formData.description,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("更新に失敗しました");
+      }
+
+      notifications.show({
+        title: "更新完了",
+        message: "連絡先情報を更新しました",
+        color: "green",
+        icon: <IconCheck size="1rem" />,
+      });
+
+      // 連絡先情報を再取得
+      const loadContactInfo = async () => {
+        try {
+          const data = await fetchContactInfo();
+          setContactInfo(data);
+        } catch (err) {
+          console.error("連絡先情報再取得エラー:", err);
+        }
+      };
+      await loadContactInfo();
+
+      handleEditModalClose();
+    } catch (error) {
+      console.error("Contact update error:", error);
+      notifications.show({
+        title: "エラー",
+        message: handleApiError(error),
+        color: "red",
+        icon: <IconX size="1rem" />,
+      });
+    } finally {
+      setIsFormLoading(false);
+    }
   };
 
   return (
     <Stack gap="lg">
       {/* ヘッダー情報 */}
       <div>
-        <Title order={3} className="mb-2">
-          管理者への連絡
-        </Title>
-        <Text size="sm" className="text-gray-600">
-          演奏会に関するお問い合わせやご質問はこちら
-        </Text>
+        <Group justify="space-between" align="flex-start">
+          <div>
+            <Title order={3} className="mb-2">
+              管理者への連絡
+            </Title>
+            <Text size="sm" className="text-gray-600">
+              演奏会に関するお問い合わせやご質問はこちら
+            </Text>
+          </div>
+          {isAdmin && contactInfo && (
+            <Button
+              variant="light"
+              size="sm"
+              leftSection={<IconEdit size="0.9rem" />}
+              onClick={handleEditModalOpen}
+              disabled={isFormLoading}
+            >
+              編集
+            </Button>
+          )}
+        </Group>
       </div>
 
       {/* メイン連絡先カード */}
@@ -134,28 +233,35 @@ export function ContactTab({}: ContactTabProps) {
             </Text>
           </div>
 
-          {/* 連絡先情報 */}
+          {/* 連絡先情報 - クリックでコピー */}
           <div className="bg-blue-50 p-4 rounded-lg border border-blue-200">
             <Group gap="sm" className="mb-2">
               <IconMail size="1.2rem" className="text-blue-600" />
               <Title order={5}>メールアドレス</Title>
             </Group>
-            <Text size="lg" className="font-mono font-semibold text-blue-800">
-              {contactInfo.email}
-            </Text>
+            <Group gap="sm" align="center">
+              <Text
+                size="lg"
+                className="font-mono font-semibold text-blue-800 cursor-pointer hover:text-blue-900 transition-colors"
+                onClick={() => clipboard.copy(contactInfo.email)}
+                title="クリックでコピー"
+              >
+                {contactInfo.email}
+              </Text>
+              <Button
+                variant="subtle"
+                size="xs"
+                color={clipboard.copied ? "green" : "blue"}
+                leftSection={
+                  clipboard.copied ? <IconCheck size="0.8rem" /> : <IconCopy size="0.8rem" />
+                }
+                onClick={() => clipboard.copy(contactInfo.email)}
+              >
+                {clipboard.copied ? "コピー済み" : "コピー"}
+              </Button>
+            </Group>
           </div>
 
-          {/* メール送信ボタン */}
-          <Group>
-            <Button
-              leftSection={<IconMail size="1rem" />}
-              onClick={handleSendEmail}
-              size="md"
-              className="w-full sm:w-auto"
-            >
-              メールで連絡する
-            </Button>
-          </Group>
 
           {/* 最終更新日時 */}
           <Text size="xs" className="text-gray-500 text-right">
@@ -221,6 +327,62 @@ export function ContactTab({}: ContactTabProps) {
           </div>
         </Stack>
       </Paper>
+
+      {/* 管理者編集モーダル */}
+      <Modal
+        opened={isEditModalOpen}
+        onClose={handleEditModalClose}
+        title="連絡先情報を編集"
+        centered
+        size="md"
+      >
+        <form onSubmit={handleFormSubmit}>
+          <Stack gap="md">
+            <TextInput
+              label="メールアドレス"
+              placeholder="admin@example.com"
+              value={formData.email}
+              onChange={(e) =>
+                setFormData({ ...formData, email: e.target.value })
+              }
+              required
+              disabled={isFormLoading}
+              data-autofocus
+            />
+
+            <Textarea
+              label="説明文"
+              placeholder="お問い合わせについての説明文を入力してください"
+              value={formData.description}
+              onChange={(e) =>
+                setFormData({ ...formData, description: e.target.value })
+              }
+              required
+              disabled={isFormLoading}
+              autosize
+              minRows={3}
+              maxRows={8}
+            />
+
+            <Group justify="flex-end" gap="sm">
+              <Button
+                variant="subtle"
+                onClick={handleEditModalClose}
+                disabled={isFormLoading}
+              >
+                キャンセル
+              </Button>
+              <Button
+                type="submit"
+                loading={isFormLoading}
+                leftSection={<IconCheck size="1rem" />}
+              >
+                更新する
+              </Button>
+            </Group>
+          </Stack>
+        </form>
+      </Modal>
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary

連絡機能を強化し、より使いやすいUIに改善しました：

- **メールボタン削除**: `mailto:`リンクを使用した「メールで連絡する」ボタンを削除
- **コピー機能追加**: メールアドレスをクリックでクリップボードにコピー可能
- **管理者編集UI**: 管理者向けの連絡先情報編集モーダルとフォームを実装
- **バリデーション強化**: メールアドレス形式チェックとエラーハンドリング
- **UX改善**: モバイルファーストデザインとレスポンシブ対応維持

## Test plan

- [x] コピー機能動作確認（デスクトップ・モバイル）
- [x] 管理者編集モーダル動作確認
- [x] フォームバリデーション確認
- [x] 成功・エラー通知確認
- [x] 非管理者権限での編集ボタン非表示確認
- [x] レスポンシブデザイン確認
- [x] 既存機能への影響なし確認

## Changes

- `src/components/features/contact/ContactTab.tsx`: 連絡機能の完全リファクタリング
  - `handleSendEmail`関数削除
  - `useClipboard`フック追加
  - 管理者編集モーダル・フォーム実装
  - バリデーションとAPI統合

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)